### PR TITLE
Revert "sm6375-common: powerhint: Add DT2W"

### DIFF
--- a/configs/powerhint.json
+++ b/configs/powerhint.json
@@ -331,14 +331,6 @@
       "ResetOnInit": true
     },
     {
-      "Name": "DoubleTapToWakeEnable",
-      "Path": "/sys/class/sensors/dt-gesture/enable",
-      "Values": [
-        "1",
-        "0"
-      ],
-    },
-    {
       "Name": "PowerHALMainState",
       "Path": "vendor.powerhal.state",
       "Values": [
@@ -639,12 +631,6 @@
       "Node": "L3BigClusterMinFreq",
       "Duration": 5000,
       "Value": "1497600000"
-    },
-    {
-      "PowerHint": "DOUBLE_TAP_TO_WAKE",
-      "Node": "DoubleTapToWakeEnable",
-      "Duration": 0,
-      "Value": "1"
     },
     {
       "PowerHint": "FIXED_PERFORMANCE",


### PR DESCRIPTION
Reason for revert: We're moving DT2W to custom sensors HAL in device specific trees.

This reverts commit 911e53bbefa20135fce0b435df0dce5567a03af0.

Change-Id: I2ba9b1551f453bd73457f027f2e834b2cdcd63b4